### PR TITLE
ID-2710: Print TraceFlags as hex since toString might not be implemented

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, Digitaliseringsdirektoratet (Digdir)
+Copyright (c) 2023, Digitaliseringsdirektoratet (Digdir)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The library can be imported through maven with (see latest version under [releas
 <dependency>
     <groupId>no.idporten.logging</groupId>
     <artifactId>idporten-access-log-spring-boot-starter</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 </dependency>
 ```
 

--- a/src/main/java/no/idporten/logging/access/AccesslogProvider.java
+++ b/src/main/java/no/idporten/logging/access/AccesslogProvider.java
@@ -82,11 +82,11 @@ public class AccesslogProvider extends AbstractFieldJsonProvider<IAccessEvent> i
                 return;
             }
             String spanId = spanContext.getSpanId();
-            String parentId = spanContext.getTraceFlags().toString();
+            String traceFlags = spanContext.getTraceFlags().asHex();
 
             jsonGenerator.writeStringField(TRACE_ID, traceId);
             jsonGenerator.writeStringField(SPAN_ID, spanId);
-            jsonGenerator.writeStringField(TRACE_FLAGS, parentId);
+            jsonGenerator.writeStringField(TRACE_FLAGS, traceFlags);
 
         } else {
             String message = String.format("traceparent not found as request header: %s or in spanContext: %s", iAccessEvent, Span.current().getSpanContext());


### PR DESCRIPTION
toString() in immutableTraceFlags only calls toHex as well. No source code found for agent implementation.