### PR TITLE
ID-4887: Only log warning on disabled of old property tomcat.accesslog

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023, Digitaliseringsdirektoratet (Digdir)
+Copyright (c) 2025, Digitaliseringsdirektoratet (Digdir)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ mvn clean install
 
 ## Usage
 The library can be imported through maven with (see latest version under [releases](https://github.com/felleslosninger/idporten-access-log-spring-boot-starter/releases)):
+
+### Spring Boot 3:
+```xml
+<dependency>
+    <groupId>no.idporten.logging</groupId>
+    <artifactId>idporten-access-log-spring-boot-3-starter</artifactId>
+    <version>2.6.0</version>
+</dependency>
+```
+
+And you probably already have included these:
+```xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-web</artifactId>
+</dependency>
+
+<dependency>
+    <groupId>io.opentelemetry.instrumentation</groupId>
+    <artifactId>opentelemetry-instrumentation-api</artifactId>
+</dependency>
+```
+
 ### Spring Boot 2:
 Warning: This version is not maintained anymore, use Spring Boot 3 version instead.
 
@@ -63,28 +86,6 @@ And you probably already have included these:
 </dependency>
 ```
 
-### Spring Boot 3:
-```xml
-<dependency>
-    <groupId>no.idporten.logging</groupId>
-    <artifactId>idporten-access-log-spring-boot-3-starter</artifactId>
-    <version>2.4.0</version>
-</dependency>
-```
-
-And you probably already have included these:
-```xml
-<dependency>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-web</artifactId>
-</dependency>
-
-<dependency>
-    <groupId>io.opentelemetry.instrumentation</groupId>
-    <artifactId>opentelemetry-instrumentation-api</artifactId>
-</dependency>
-```
-
 ### Configuration
 The library is configured through the application.yml/yaml or the active spring profile yaml-file.
 ```yaml
@@ -101,6 +102,7 @@ server:
     accesslog:
       enabled: true # default is true if not set
 ```
+Only include this property if you need to disable access logging, since it is always default enabled.
 
 Use your own logback-access.xml file or configure debug-logging:
 ```yaml

--- a/idporten-access-log-spring-boot-3-starter/src/main/java/no/idporten/logging/access/AccessLogsConfiguration.java
+++ b/idporten-access-log-spring-boot-3-starter/src/main/java/no/idporten/logging/access/AccessLogsConfiguration.java
@@ -48,8 +48,8 @@ public class AccessLogsConfiguration {
 
         log.info("Initialize accessLogsCustomizer for Tomcat Access Logging as JSON. Use config-file: {}", logbackConfigFile);
 
-        if (deprecatedTomcatAccessLogProperty != null && !deprecatedTomcatAccessLogProperty.equals("enabled")) { // deprecated property is set, and set to something else than 'enabled'
-            log.warn("Property 'tomcat.accesslog' is deprecated. Use 'server.tomcat.accesslog.enabled=false' instead.");
+        if (deprecatedTomcatAccessLogProperty != null && deprecatedTomcatAccessLogProperty.equals("disabled")) { // deprecated property is set to 'disabled'
+            log.warn("Property 'tomcat.accesslog' is deprecated. Use 'server.tomcat.accesslog.enabled=false' instead or remove if you need Tomcat access logging.");
         }
 
         return factory -> {
@@ -91,8 +91,8 @@ public class AccessLogsConfiguration {
      * Use application provided logback-access.xml if property digdir.access.logging.config-file is configured,
      * otherwise check if debug-level is configured.
      *
-     * @param configFile
-     * @param debug
+     * @param configFile logback-access.xml
+     * @param debug only used when configFile is default logback-access.xml
      */
     protected String checkIfDebugFeatureEnabledAndConfigureLogbackfile(String configFile, String debug) {
 


### PR DESCRIPTION
 since enabled is anyway default and thus not used.

Fix bug with always logging this:
`Property 'tomcat.accesslog' is deprecated. Use 'server.tomcat.accesslog.enabled=false' instead.`