### PR TITLE
ID-6697: Fix tomcat.version regression in spring-boot-4-starter

### DIFF
--- a/idporten-access-log-spring-boot-4-starter/pom.xml
+++ b/idporten-access-log-spring-boot-4-starter/pom.xml
@@ -22,7 +22,7 @@
         <spring-boot.version>4.1.0</spring-boot.version>
         <logstash-logback-encoder.version>9.0</logstash-logback-encoder.version>
         <logback-access.version>2.0.14</logback-access.version>
-        <tomcat.version>10.1.57</tomcat.version>
+        <tomcat.version>11.0.22</tomcat.version>
         <argLine />
     </properties>
 


### PR DESCRIPTION
SAK: https://digdir.atlassian.net/browse/ID-6697
ID-6697

Sjekklister:
Eigar:

- [x] Vurdert breaking changes
- [x] Avhengigheter til andre saker avklart
- [x] Testet mot en eller flere tjenester som bruker biblioteket
- [x] Unngått å legge til unødvendige avhengigheter
- [x] Har oppdatert dependabots

Kodeles:

- [x] Lesbar kode, nødvendige kommentarer
- [x] Sak er godt nok forklart/dokumentert
- [x] Løyser saka
- [x] Risikovurdering ok
- [x] Nødvendige unit-tester er på plass
- [ ] Har oppdatert readme

## Summary

Merging #267 (`tomcat-catalina` 10.1.55 → 10.1.57, intended for the `idporten-access-log-spring-boot-3-starter` module) overwrote `idporten-access-log-spring-boot-4-starter`'s own `tomcat.version` back down from `11.0.22` to `10.1.57`. That value was set in #266 to match the Tomcat version Spring Boot 4.1.0 itself manages. This restores `tomcat.version` to `11.0.22` in the 4-starter module only.
