### PR TITLE
MIN-3564 Alltid logge access-loggar som INFO

### DIFF
--- a/idporten-access-log-common/src/main/resources/logback-access-req-full.xml
+++ b/idporten-access-log-common/src/main/resources/logback-access-req-full.xml
@@ -12,6 +12,7 @@
                         "@version" : "1",
                         "@type" : "access",
                         "logtype": "tomcat-access",
+                        "level": "INFO",
                         "x_forwarded_for": "%header{X-Forwarded-For}",
                         "client_host" : "%clientHost",
                         "remote_user" : "%user",

--- a/idporten-access-log-common/src/main/resources/logback-access-req-resp-full.xml
+++ b/idporten-access-log-common/src/main/resources/logback-access-req-resp-full.xml
@@ -12,6 +12,7 @@
                         "@version" : "1",
                         "@type" : "access",
                         "logtype": "tomcat-access",
+                        "level": "INFO",
                         "x_forwarded_for": "%header{X-Forwarded-For}",
                         "client_host" : "%clientHost",
                         "remote_user" : "%user",

--- a/idporten-access-log-common/src/main/resources/logback-access.xml
+++ b/idporten-access-log-common/src/main/resources/logback-access.xml
@@ -12,6 +12,7 @@
                         "@version" : "1",
                         "@type" : "access",
                         "logtype": "tomcat-access",
+                        "level": "INFO",
                         "x_forwarded_for": "%header{X-Forwarded-For}",
                         "client_host" : "%clientHost",
                         "remote_user" : "%user",

--- a/idporten-access-log-common/src/main/resources/logback-access.xml
+++ b/idporten-access-log-common/src/main/resources/logback-access.xml
@@ -12,7 +12,6 @@
                         "@version" : "1",
                         "@type" : "access",
                         "logtype": "tomcat-access",
-                        "level": "INFO",
                         "x_forwarded_for": "%header{X-Forwarded-For}",
                         "client_host" : "%clientHost",
                         "remote_user" : "%user",

--- a/idporten-access-log-spring-boot-3-starter/src/test/java/no/idporten/logging/access/AccessLogLogbackIT.java
+++ b/idporten-access-log-spring-boot-3-starter/src/test/java/no/idporten/logging/access/AccessLogLogbackIT.java
@@ -89,6 +89,7 @@ class AccessLogLogbackIT {
                 .untilAsserted(() -> {
                     assertThat(output.getOut()).contains("\"@type\":\"access\"");
                     assertThat(output.getOut()).contains("\"logtype\":\"tomcat-access\"");
+                    assertThat(output.getOut()).contains("\"level\":\"INFO\"");
                     assertThat(output.getOut()).contains("\"request_method\":\"GET\"");
                     assertThat(output.getOut()).contains("\"request_uri\":\"/test\"");
                     assertThat(output.getOut()).contains("\"status_code\":200");

--- a/idporten-access-log-spring-boot-4-starter/src/test/java/no/idporten/logging/access/AccessLogLogbackIT.java
+++ b/idporten-access-log-spring-boot-4-starter/src/test/java/no/idporten/logging/access/AccessLogLogbackIT.java
@@ -89,6 +89,7 @@ class AccessLogLogbackIT {
                 .untilAsserted(() -> {
                     assertThat(output.getOut()).contains("\"@type\":\"access\"");
                     assertThat(output.getOut()).contains("\"logtype\":\"tomcat-access\"");
+                    assertThat(output.getOut()).contains("\"level\":\"INFO\"");
                     assertThat(output.getOut()).contains("\"request_method\":\"GET\"");
                     assertThat(output.getOut()).contains("\"request_uri\":\"/test\"");
                     assertThat(output.getOut()).contains("\"status_code\":200");


### PR DESCRIPTION
Dersom ein access-log inneheld ordet "error" so blir access-loggen logga på nivå ERROR sidan lognivået ikkje er spesifisert i config. Eg reknar med dette ikkje er intended. 
Døme: 
<img width="856" height="36" alt="image" src="https://github.com/user-attachments/assets/986e7927-2eda-4f25-b4ea-c1009ba6c389" />
<img width="872" height="52" alt="image" src="https://github.com/user-attachments/assets/6803e692-7b6a-473a-80a5-1d91ae4b1452" />
